### PR TITLE
Create floodgates banner

### DIFF
--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -2043,7 +2043,8 @@ export interface components {
     readonly PlayerInfo: {
       /** Format: int64 */
       readonly membershipId: string;
-      readonly membershipType: components["schemas"]["DestinyMembershipType"];
+      /** @description The platform on which the player created their account. */
+      readonly membershipType: components["schemas"]["DestinyMembershipType"] | null;
       readonly iconPath: string | null;
       /** @description The platform-specific display name of the player. No longer shown in-game. */
       readonly displayName: string | null;
@@ -2128,10 +2129,10 @@ export interface components {
     };
     readonly ClanStats: {
       readonly aggregateStats: components["schemas"]["ClanAggregateStats"];
-      readonly members: readonly {
-          readonly playerInfo: components["schemas"]["PlayerInfo"];
+      readonly members: readonly ({
+          readonly playerInfo: components["schemas"]["PlayerInfo"] | null;
           readonly stats: components["schemas"]["ClanMemberStats"];
-        }[];
+        })[];
     };
     readonly TeamLeaderboardEntry: {
       readonly position: number;
@@ -2197,13 +2198,13 @@ export interface components {
       readonly isSunset: boolean;
       readonly isRaid: boolean;
       /** Format: date-time */
-      readonly releaseDate: string;
+      readonly releaseDate: string | null;
       /** Format: date-time */
-      readonly dayOneEnd: string;
+      readonly dayOneEnd: string | null;
       /** Format: date-time */
-      readonly contestEnd: string;
+      readonly contestEnd: string | null;
       /** Format: date-time */
-      readonly weekOneEnd: string;
+      readonly weekOneEnd: string | null;
       /** Format: uint32 */
       readonly milestoneHash: number | null;
     };
@@ -2248,7 +2249,7 @@ export interface components {
               readonly iconPath?: string | null;
               readonly crossSaveOverride: components["schemas"]["DestinyMembershipType"];
               readonly applicableMembershipTypes?: (readonly components["schemas"]["DestinyMembershipType"][]) | null;
-              readonly membershipType?: components["schemas"]["DestinyMembershipType"];
+              readonly membershipType?: components["schemas"]["DestinyMembershipType"] | null;
               readonly membershipId: string;
               readonly displayName?: string | null;
               readonly bungieGlobalDisplayName?: string | null;
@@ -2309,17 +2310,17 @@ export interface components {
       readonly freshClears: number;
       readonly clears: number;
       readonly sherpas: number;
-      readonly fastestInstance: components["schemas"]["Instance"];
+      readonly fastestInstance: components["schemas"]["Instance"] | null;
     };
     readonly GlobalStat: {
       readonly rank: number;
       readonly value: number;
     };
     readonly PlayerProfileGlobalStats: {
-      readonly clears: components["schemas"]["GlobalStat"];
-      readonly freshClears: components["schemas"]["GlobalStat"];
-      readonly sherpas: components["schemas"]["GlobalStat"];
-      readonly sumOfBest: components["schemas"]["GlobalStat"];
+      readonly clears: components["schemas"]["GlobalStat"] | null;
+      readonly freshClears: components["schemas"]["GlobalStat"] | null;
+      readonly sherpas: components["schemas"]["GlobalStat"] | null;
+      readonly sumOfBest: components["schemas"]["GlobalStat"] | null;
     };
     readonly WorldFirstEntry: {
       readonly activityId: number;
@@ -2341,7 +2342,7 @@ export interface components {
         };
       };
       readonly worldFirstEntries: {
-        [key: string]: components["schemas"]["WorldFirstEntry"];
+        [key: string]: components["schemas"]["WorldFirstEntry"] | null;
       };
     };
     readonly Teammate: {
@@ -2349,6 +2350,31 @@ export interface components {
       readonly clears: number;
       readonly instanceCount: number;
       readonly playerInfo: components["schemas"]["PlayerInfo"];
+    };
+    readonly LatestResolvedInstance: {
+      /** Format: date-time */
+      readonly dateCompleted: string;
+      /** Format: date-time */
+      readonly dateResolved: string;
+      readonly instanceId: string;
+    };
+    readonly AtlasStatus: {
+      /** @enum {string} */
+      readonly status: "Crawling" | "Idle" | "Offline";
+      readonly medianSecondsBehindNow: number | null;
+      /** Format: date-time */
+      readonly estimatedCatchUpTimestamp: string | null;
+      readonly latestResolvedInstance: components["schemas"]["LatestResolvedInstance"];
+    };
+    readonly FloodgatesStatus: {
+      /** @enum {string} */
+      readonly status: "Empty" | "Blocked" | "Crawling" | "Live";
+      readonly incomingRate: number;
+      readonly resolveRate: number;
+      readonly backlog: number;
+      readonly latestResolvedInstance: components["schemas"]["LatestResolvedInstance"] | null;
+      /** Format: date-time */
+      readonly estimatedBacklogEmptied: string | null;
     };
     readonly ManifestResponse: {
       /** @description The mapping of each Bungie.net hash to a RaidHub activityId and versionId */
@@ -2388,18 +2414,8 @@ export interface components {
       };
     };
     readonly StatusResponse: {
-      readonly AtlasPGCR: {
-        /** @enum {string} */
-        readonly status: "Crawling" | "Idle" | "Offline";
-        readonly medianSecondsBehindNow: number | null;
-        /** Format: date-time */
-        readonly estimatedCatchUpTimestamp: string;
-        readonly latestActivity: {
-          /** Format: date-time */
-          readonly dateCompleted: string;
-          readonly instanceId: string;
-        };
-      };
+      readonly AtlasPGCR: components["schemas"]["AtlasStatus"];
+      readonly FloodgatesPGCR: components["schemas"]["FloodgatesStatus"];
     };
     readonly PlayerSearchResponse: {
       readonly params: {
@@ -2411,7 +2427,7 @@ export interface components {
     readonly PlayerActivitiesResponse: {
       readonly membershipId: string;
       /** Format: date-time */
-      readonly nextCursor: string;
+      readonly nextCursor: string | null;
       readonly activities: readonly components["schemas"]["InstanceForPlayer"][];
     };
     readonly PlayerNotFoundError: {
@@ -2435,7 +2451,8 @@ export interface components {
     readonly PlayerBasicResponse: {
       /** Format: int64 */
       readonly membershipId: string;
-      readonly membershipType: components["schemas"]["DestinyMembershipType"];
+      /** @description The platform on which the player created their account. */
+      readonly membershipType: components["schemas"]["DestinyMembershipType"] | null;
       readonly iconPath: string | null;
       /** @description The platform-specific display name of the player. No longer shown in-game. */
       readonly displayName: string | null;
@@ -2455,7 +2472,7 @@ export interface components {
         };
       };
       readonly worldFirstEntries: {
-        [key: string]: components["schemas"]["WorldFirstEntry"];
+        [key: string]: components["schemas"]["WorldFirstEntry"] | null;
       };
     };
     readonly PlayerTeammatesResponse: readonly components["schemas"]["Teammate"][];
@@ -2593,7 +2610,7 @@ export interface components {
               readonly iconPath?: string | null;
               readonly crossSaveOverride: components["schemas"]["DestinyMembershipType"];
               readonly applicableMembershipTypes?: (readonly components["schemas"]["DestinyMembershipType"][]) | null;
-              readonly membershipType?: components["schemas"]["DestinyMembershipType"];
+              readonly membershipType?: components["schemas"]["DestinyMembershipType"] | null;
               readonly membershipId: string;
               readonly displayName?: string | null;
               readonly bungieGlobalDisplayName?: string | null;
@@ -2648,10 +2665,10 @@ export interface components {
     };
     readonly ClanResponse: {
       readonly aggregateStats: components["schemas"]["ClanAggregateStats"];
-      readonly members: readonly {
-          readonly playerInfo: components["schemas"]["PlayerInfo"];
+      readonly members: readonly ({
+          readonly playerInfo: components["schemas"]["PlayerInfo"] | null;
           readonly stats: components["schemas"]["ClanMemberStats"];
-        }[];
+        })[];
     };
     readonly ClanNotFoundError: {
       readonly groupId: string;

--- a/src/services/raidhub/useRaidHubStatus.ts
+++ b/src/services/raidhub/useRaidHubStatus.ts
@@ -12,23 +12,40 @@ export const useRaidHubStatus = () =>
         refetchIntervalInBackground: false,
         retry: 3,
         refetchInterval: data => {
-            if (!data) return 60000
+            if (!data) return 30_000
 
-            switch (data.AtlasPGCR.status) {
-                case "Crawling":
-                    if (
-                        data.AtlasPGCR.medianSecondsBehindNow &&
-                        data.AtlasPGCR.medianSecondsBehindNow > 60
-                    ) {
-                        return 30_000
-                    }
-                    return 120_000
-                case "Idle":
-                    return 300_000
-                case "Offline":
-                    return 45_000
-                default:
-                    return 60_000
+            const getAtlasInterval = () => {
+                switch (data.AtlasPGCR.status) {
+                    case "Crawling":
+                        if (
+                            data.AtlasPGCR.medianSecondsBehindNow &&
+                            data.AtlasPGCR.medianSecondsBehindNow > 60
+                        ) {
+                            return 30_000
+                        }
+                        return 120_000
+                    case "Idle":
+                        return 300_000
+                    case "Offline":
+                        return 45_000
+                    default:
+                        return 60_000
+                }
             }
+
+            const getFloodgatesInterval = () => {
+                switch (data.FloodgatesPGCR.status) {
+                    case "Blocked":
+                        return 20_000
+                    case "Crawling":
+                        return 15_000
+                    case "Live":
+                        return 60_000
+                    case "Empty":
+                        return 600_000
+                }
+            }
+
+            return Math.min(getAtlasInterval(), getFloodgatesInterval())
         }
     })


### PR DESCRIPTION
This pull request introduces significant updates to the `RaidHubStatusBanner` component and its supporting logic to handle a new `FloodgatesState` and improve the status reporting for both `AtlasState` and `FloodgatesState`. The changes include updates to type definitions, component logic, and status intervals to provide more granular and accurate information.

### Updates to Type Definitions and State Handling:
* Replaced `lastCrawledDate` with `lastCompletedDate` in the `AtlasState` type and updated all relevant references in the `RaidHubStatusBanner` component. [[1]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71L21-R69) [[2]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71L64-R95) [[3]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71L73-R109) [[4]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71L107-R192) [[5]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71L142-R227)
* Introduced a new `FloodgatesState` type to represent the state of floodgates with various statuses such as `loading`, `ok`, `closed`, `emptying`, and `emptying2`.

### Component Enhancements:
* Added a `useMemo` hook to compute the `FloodgatesState` based on the `statusQuery` data, providing detailed handling for different floodgate statuses.
* Introduced a new `RaidHubFloodgatesBannerInner` component to display floodgate-specific banners, including backlog size, incoming rate, and estimated catchup times.
* Updated the `RaidHubAtlasBannerInner` component to replace the previous `RaidHubStatsBannerInner` and reflect the changes to `AtlasState`. [[1]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71R120-R181) [[2]](diffhunk://#diff-380b49718adf063c3508dea195cbdda6bc63b01c4d899b731bd8d6c0abc37d71R252-R320)

### Status Interval Adjustments:
* Modified the `useRaidHubStatus` hook to include dynamic interval calculations for both `AtlasState` and `FloodgatesState`, ensuring more responsive updates based on their respective statuses. [[1]](diffhunk://#diff-1e1feb6534e8bbb8f3eac82e09543c0ec3465beb5e32f5ed9782767c591990a0L15-R17) [[2]](diffhunk://#diff-1e1feb6534e8bbb8f3eac82e09543c0ec3465beb5e32f5ed9782767c591990a0R35-R50)